### PR TITLE
Start work on checkpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
-
-[[package]]
 name = "syn"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,7 +42,6 @@ name = "syntree"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "slab",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ A memory efficient syntax tree for language developers.
 """
 
 [dependencies]
-slab = "0.4.5"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/examples/checkpoint.rs
+++ b/examples/checkpoint.rs
@@ -4,34 +4,28 @@ use syntree::{print, Span, TreeBuilder};
 #[derive(Debug, Clone, Copy)]
 enum Syntax {
     Root,
-    Operation,
     Number,
-    Plus,
+    Lit,
+    Whitespace,
 }
 
 fn main() -> Result<()> {
     let mut b = TreeBuilder::new();
 
-    b.start_node(Syntax::Root);
-    b.end_node()?;
-
-    b.start_node(Syntax::Root);
-    b.start_node(Syntax::Operation);
+    let c = b.checkpoint();
 
     b.start_node(Syntax::Number);
-    b.token(Syntax::Number, Span::new(0, 4));
+    b.token(Syntax::Lit, Span::new(1, 2));
     b.end_node()?;
 
-    b.start_node(Syntax::Plus);
-    b.token(Syntax::Plus, Span::new(4, 5));
-    b.end_node()?;
+    b.token(Syntax::Whitespace, Span::new(2, 5));
 
     b.start_node(Syntax::Number);
-    b.token(Syntax::Number, Span::new(5, 10));
+    b.token(Syntax::Lit, Span::new(5, 7));
+    b.token(Syntax::Lit, Span::new(7, 9));
     b.end_node()?;
 
-    b.end_node()?;
-    b.end_node()?;
+    b.insert_node_at(c, Syntax::Root);
 
     let tree = b.build()?;
 

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,0 +1,26 @@
+use syntree::TreeBuilder;
+
+fn main() -> anyhow::Result<()> {
+    let mut tree = TreeBuilder::new();
+
+    tree.start_node("root1");
+
+    tree.start_node("child1");
+    tree.end_node()?;
+
+    tree.start_node("child2");
+    tree.end_node()?;
+
+    tree.end_node()?;
+
+    tree.start_node("root2");
+    tree.end_node()?;
+
+    let tree = tree.build()?;
+    let mut it = tree.children();
+
+    assert_eq!(it.next().map(|n| *n.data()), Some("root1"));
+    assert_eq!(it.next().map(|n| *n.data()), Some("root2"));
+    assert!(it.next().is_none());
+    Ok(())
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,14 @@
+use std::{fmt, mem};
+
 use thiserror::Error;
 
 use crate::tree::Kind;
 use crate::{Id, Span, Tree};
+
+/// A checkpoint which indicates a position in the tree where an element can be
+/// optionally inserted.
+#[derive(Debug, Clone, Copy)]
+pub struct Checkpoint(usize);
 
 /// Error raised by [TreeBuilder::end_node] if there currently is no node being
 /// built.
@@ -23,21 +30,23 @@ pub(crate) struct Element<T> {
     pub(crate) data: T,
     /// The kind of the element.
     pub(crate) kind: Kind,
-    /// Next sibling number.
-    pub(crate) next: Option<usize>,
-    /// Head to the next child element.
-    pub(crate) child: Option<usize>,
+    /// Next sibling id.
+    pub(crate) next: usize,
+    /// The first child element.
+    pub(crate) first: usize,
+    /// The parent node.
+    pub(crate) parent: usize,
 }
 
 /// A syntax tree.
 #[derive(Debug)]
 pub struct TreeBuilder<T> {
-    ///  Data in the tree being built.
-    data: slab::Slab<Element<T>>,
+    /// Data in the tree being built.
+    pub(crate) data: Vec<Element<T>>,
     /// Nodes currently being built.
     stack: Vec<usize>,
     /// The last sibling inserted.
-    sibling: Option<usize>,
+    sibling: usize,
 }
 
 /// Build a new syntax tree.
@@ -99,7 +108,7 @@ impl<T> TreeBuilder<T> {
     pub fn start_node(&mut self, data: T) -> Id {
         let id = self.insert(data, Kind::Node);
         self.stack.push(id);
-        Id(id.try_into().expect("identifier out of bounds"))
+        Id(id)
     }
 
     /// End a node being built. This call must be balanced with
@@ -134,7 +143,7 @@ impl<T> TreeBuilder<T> {
             None => return Err(EndNodeError),
         };
 
-        self.sibling = Some(head);
+        self.sibling = head;
         Ok(())
     }
 
@@ -169,8 +178,131 @@ impl<T> TreeBuilder<T> {
     /// ```
     pub fn token(&mut self, data: T, span: Span) -> Id {
         let id = self.insert(data, Kind::Token(span));
-        self.sibling = Some(id);
-        Id(id.try_into().expect("identifier out of bounds"))
+        self.sibling = id;
+        Id(id)
+    }
+
+    /// Get a checkpoint corresponding to the current position in the tree.
+    ///
+    /// ```
+    /// use anyhow::Result;
+    /// use syntree::{print, Span, TreeBuilder};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    /// enum Syntax {
+    ///     Root,
+    ///     Number,
+    ///     Lit,
+    ///     Whitespace,
+    /// }
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut b = TreeBuilder::new();
+    ///
+    /// let c = b.checkpoint();
+    ///
+    /// b.start_node(Syntax::Number);
+    /// b.token(Syntax::Lit, Span::new(1, 2));
+    /// b.end_node()?;
+    ///
+    /// b.token(Syntax::Whitespace, Span::new(2, 5));
+    ///
+    /// b.start_node(Syntax::Number);
+    /// b.token(Syntax::Lit, Span::new(5, 7));
+    /// b.token(Syntax::Lit, Span::new(7, 9));
+    /// b.end_node()?;
+    ///
+    /// b.insert_node_at(c, Syntax::Root);
+    ///
+    /// let tree = b.build()?;
+    ///
+    /// let root = tree.first().unwrap();
+    /// assert_eq!(*root.data(), Syntax::Root);
+    /// assert_eq!(root.children().count(), 3);
+    /// # Ok(()) }
+    /// ```
+    pub fn checkpoint(&self) -> Checkpoint {
+        Checkpoint(self.data.len())
+    }
+
+    /// Insert a node that wraps from the given checkpointed location.
+    ///
+    /// ```
+    /// use anyhow::Result;
+    /// use syntree::{print, Span, TreeBuilder};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    /// enum Syntax {
+    ///     Root,
+    ///     Number,
+    ///     Lit,
+    ///     Whitespace,
+    /// }
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let mut b = TreeBuilder::new();
+    ///
+    /// let c = b.checkpoint();
+    ///
+    /// b.start_node(Syntax::Number);
+    /// b.token(Syntax::Lit, Span::new(1, 2));
+    /// b.end_node()?;
+    ///
+    /// b.token(Syntax::Whitespace, Span::new(2, 5));
+    ///
+    /// b.start_node(Syntax::Number);
+    /// b.token(Syntax::Lit, Span::new(5, 7));
+    /// b.token(Syntax::Lit, Span::new(7, 9));
+    /// b.end_node()?;
+    ///
+    /// b.insert_node_at(c, Syntax::Root);
+    ///
+    /// let tree = b.build()?;
+    ///
+    /// let root = tree.first().unwrap();
+    /// assert_eq!(*root.data(), Syntax::Root);
+    /// assert_eq!(root.children().count(), 3);
+    /// # Ok(()) }
+    /// ```
+    pub fn insert_node_at(&mut self, c: Checkpoint, data: T) -> Id
+    where
+        T: fmt::Debug,
+    {
+        // With the layout of this data structure this is a fairly simple
+        // operation.
+        let child = self.data.len();
+
+        let mut removed = match self.data.get_mut(c.0) {
+            Some(entry) => {
+                let new = Element {
+                    data,
+                    kind: Kind::Node,
+                    next: usize::MAX,
+                    first: child,
+                    parent: entry.parent,
+                };
+
+                mem::replace(entry, new)
+            }
+            None => {
+                return Id(self.insert(data, Kind::Node));
+            }
+        };
+
+        let mut cur = removed.next;
+
+        while cur != usize::MAX {
+            let el = &mut self.data[cur];
+            el.parent = c.0;
+            cur = el.next;
+        }
+
+        removed.parent = c.0;
+        self.data.push(removed);
+
+        // The current sibling is the newly replaced node in the tree.
+        self.sibling = c.0;
+        Id(c.0)
     }
 
     /// Construct a tree.
@@ -231,7 +363,7 @@ impl<T> TreeBuilder<T> {
     /// ```
     pub fn build(&self) -> Result<Tree<T>, IntoTreeError>
     where
-        T: Copy,
+        T: fmt::Debug + Copy,
     {
         if !self.stack.is_empty() {
             return Err(IntoTreeError);
@@ -240,29 +372,28 @@ impl<T> TreeBuilder<T> {
         Ok(crate::convert::builder_to_tree(self))
     }
 
-    /// Get the element with the given `id`.
-    pub(crate) fn get(&self, id: usize) -> Option<&Element<T>> {
-        self.data.get(id)
-    }
-
     /// Insert a new node.
     fn insert(&mut self, data: T, kind: Kind) -> usize {
-        let new = self.data.insert(Element {
+        let new = self.data.len();
+
+        let prev = std::mem::replace(&mut self.sibling, usize::MAX);
+        let parent = self.stack.last().copied().unwrap_or(usize::MAX);
+
+        self.data.push(Element {
             data,
             kind,
-            next: None,
-            child: None,
+            next: usize::MAX,
+            first: usize::MAX,
+            parent,
         });
 
-        if let Some(n) = self.sibling.take().and_then(|id| self.data.get_mut(id)) {
-            n.next = Some(new);
+        if let Some(prev) = self.data.get_mut(prev) {
+            prev.next = new;
         }
 
-        let last = self.stack.last().copied();
-
-        if let Some(n) = last.and_then(|id| self.data.get_mut(id)) {
-            if n.child.is_none() {
-                n.child = Some(new);
+        if let Some(n) = self.data.get_mut(parent) {
+            if n.first == usize::MAX {
+                n.first = new;
             }
         }
 
@@ -275,7 +406,7 @@ impl<T> Default for TreeBuilder<T> {
         Self {
             data: Default::default(),
             stack: Vec::new(),
-            sibling: None,
+            sibling: usize::MAX,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,10 @@ pub use self::span::Span;
 mod tree;
 pub use self::tree::{Kind, Tree};
 
+pub mod print;
+
 /// The identifier of a node as returned by functions such as
 /// [TreeBuilder::start_node] or [TreeBuilder::token].
 #[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
-pub struct Id(u32);
+pub struct Id(usize);

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,0 +1,45 @@
+//! Helper utilities for pretty-printing trees.
+
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::io::{Error, Write};
+
+use crate::{Kind, Tree};
+
+/// Pretty-print a tree.
+pub fn print<O, T>(o: &mut O, tree: &Tree<T>) -> Result<(), Error>
+where
+    O: Write,
+    T: Debug,
+{
+    let mut stack = VecDeque::new();
+    stack.extend(tree.children().map(|n| (true, 0, n)));
+
+    while let Some((indent, n, node)) = stack.pop_front() {
+        let data = node.data();
+
+        if let Kind::Token(span) = node.kind() {
+            writeln!(o, "{:indent$}{:?} {}", "", data, span, indent = n)?;
+            continue;
+        }
+
+        if node.is_empty() {
+            writeln!(o, "{:indent$}== {:?}", "", data, indent = n)?;
+            continue;
+        }
+
+        if indent {
+            writeln!(o, "{:indent$}>> {:?}", "", data, indent = n)?;
+
+            stack.push_front((false, n, node));
+
+            for out in node.children().rev() {
+                stack.push_front((true, n + 2, out));
+            }
+        } else {
+            writeln!(o, "{:indent$}<< {:?}", "", data, indent = n)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -281,41 +281,12 @@ impl<'a, T> Copy for Node<'a, T> {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct Internal<T> {
-    data: T,
-    kind: Kind,
-    prev: usize,
-    next: usize,
-    first: usize,
-    last: usize,
-}
-
-impl<T> Internal<T> {
-    pub(crate) fn new(data: T, kind: Kind, prev: usize) -> Self {
-        Self {
-            data,
-            kind,
-            prev,
-            next: usize::MAX,
-            first: usize::MAX,
-            last: usize::MAX,
-        }
-    }
-
-    pub(crate) fn next_mut(&mut self) -> &mut usize {
-        &mut self.next
-    }
-
-    pub(crate) fn first(&self) -> usize {
-        self.first
-    }
-
-    pub(crate) fn first_mut(&mut self) -> &mut usize {
-        &mut self.first
-    }
-
-    pub(crate) fn last_mut(&mut self) -> &mut usize {
-        &mut self.last
-    }
+    pub(crate) data: T,
+    pub(crate) kind: Kind,
+    pub(crate) prev: usize,
+    pub(crate) next: usize,
+    pub(crate) first: usize,
+    pub(crate) last: usize,
 }
 
 /// A syntax tree.


### PR DESCRIPTION
This introduces basic checkpoints which ensures a well-balanced tree.

Checkpointing is used to decide late in a parsing process what node to emit.

```rust
use anyhow::Result;
use syntree::{print, Span, TreeBuilder};

#[derive(Debug, Clone, Copy)]
enum Syntax {
    Root,
    Number,
    Lit,
    Whitespace,
}

fn main() -> Result<()> {
    let mut b = TreeBuilder::new();

    let c = b.checkpoint();

    b.start_node(Syntax::Number);
    b.token(Syntax::Lit, Span::new(1, 2));
    b.end_node()?;

    b.token(Syntax::Whitespace, Span::new(2, 5));

    b.start_node(Syntax::Number);
    b.token(Syntax::Lit, Span::new(5, 7));
    b.token(Syntax::Lit, Span::new(7, 9));
    b.end_node()?;

    b.insert_node_at(c, Syntax::Root);

    let tree = b.build()?;

    print::print(&mut std::io::stdout(), &tree)?;
    Ok(())
}
```