### PR TITLE
Rework how index is specified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,28 @@ on:
       - main
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
+      - run: cargo build --all --all-targets
+      - run: cargo build --all --all-targets
+        env:
+          RUSTFLAGS: "--cfg syntree_compact"
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
+      - run: rustup toolchain install stable --profile minimal
       - run: cargo test --all
 
   test_syntree_compact:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
+      - run: rustup toolchain install stable --profile minimal
       - run: cargo test --all
         env:
           RUSTFLAGS: "--cfg syntree_compact"
@@ -34,10 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
+      - run: rustup toolchain install nightly --profile minimal
       - run: cargo +nightly doc
         env:
           RUSTFLAGS: --cfg docsrs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ categories = ["parsing"]
 autobenches = false
 
 [dev-dependencies]
-anyhow = "1.0.66"
-thiserror = "1.0.37"
+anyhow = "1.0.69"
+thiserror = "1.0.38"
 codespan-reporting = "0.11.1"
 
 [workspace] 

--- a/examples/calculator/parsing.rs
+++ b/examples/calculator/parsing.rs
@@ -7,7 +7,7 @@ use Syntax::{EOF, WHITESPACE};
 /// Parser and lexer baked into one.
 pub(crate) struct Parser<'a> {
     lexer: Lexer<'a>,
-    pub(crate) tree: Builder<Syntax>,
+    pub(crate) tree: Builder<Syntax, u32>,
     // One token of lookahead.
     buf: Option<Token>,
 }

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -22,12 +22,18 @@ enum Syntax {
 
 use Syntax::{ADD, DIV, ERROR, MUL, NUMBER, OPERATION, ROOT, SUB, WHITESPACE};
 
-struct Parser<I: Iterator<Item = (Syntax, usize)>> {
-    builder: Builder<Syntax>,
-    iter: Peekable<I>,
+struct Parser<Iter>
+where
+    Iter: Iterator<Item = (Syntax, usize)>,
+{
+    builder: Builder<Syntax, u32>,
+    iter: Peekable<Iter>,
 }
 
-impl<I: Iterator<Item = (Syntax, usize)>> Parser<I> {
+impl<Iter> Parser<Iter>
+where
+    Iter: Iterator<Item = (Syntax, usize)>,
+{
     fn peek(&mut self) -> Result<Option<Syntax>, Error> {
         while self.iter.peek().map_or(false, |&(t, _)| t == WHITESPACE) {
             self.bump()?;
@@ -83,7 +89,7 @@ impl<I: Iterator<Item = (Syntax, usize)>> Parser<I> {
         self.handle_operation(&[ADD, SUB], Self::parse_mul)
     }
 
-    fn parse(mut self) -> Result<Tree<Syntax>, Error> {
+    fn parse(mut self) -> Result<Tree<Syntax, u32>, Error> {
         self.builder.open(ROOT)?;
         self.parse_add()?;
         self.builder.close()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,15 +24,76 @@
 //!
 //! <br>
 //!
-//! ## Enabling `syntree_compact`
+//! ## Compact or empty spans
 //!
-//! We support a configuration option to reduce the size of the tree in memory.
-//! It changes the tree from using `usize` as indexes to use `u32` which saves 4
-//! bytes per reference on 64-bit platforms.
+//! Spans by default uses `u32`-based indexes, if this is not sufficient they
+//! can be changed using the [`Builder::new_with`] constructor.
 //!
-//! This can be enabled by setting `--cfg syntree_compact` while building and
-//! might improve performance due to allowing nodes to fit neatly on individual
-//! cache lines.
+//! ```
+//! use syntree::{Builder, Span, Tree};
+//!
+//! let mut tree = Builder::<_, usize>::new_with();
+//!
+//! tree.open("root")?;
+//! tree.open("child")?;
+//! tree.token("token", 100)?;
+//! tree.close()?;
+//! tree.open("child2")?;
+//! tree.close()?;
+//! tree.close()?;
+//!
+//! let tree = tree.build()?;
+//!
+//! let expected: Tree<_, usize> = syntree::tree_with! {
+//!     "root" => {
+//!         "child" => { ("token", 100) },
+//!         "child2" => {}
+//!     }
+//! };
+//!
+//! assert_eq!(tree, expected);
+//! assert_eq!(tree.span(), Span::new(0, 100));
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! Combined with [`span::Empty`], this allows for building trees without the
+//! overhead of keeping track of spans:
+//!
+//! ```
+//! use syntree::{Builder, span, Tree};
+//!
+//! let mut tree = Builder::<_, span::Empty>::new_with();
+//!
+//! tree.open("root")?;
+//! tree.open("child")?;
+//! tree.token("token", span::Empty)?;
+//! tree.close()?;
+//! tree.open("child2")?;
+//! tree.close()?;
+//! tree.close()?;
+//!
+//! let tree = tree.build()?;
+//!
+//! let expected: Tree<_, span::Empty> = syntree::tree_with! {
+//!     "root" => {
+//!         "child" => { "token" },
+//!         "child2" => {}
+//!     }
+//! };
+//!
+//! assert_eq!(tree, expected);
+//! assert!(tree.span().is_empty());
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! <br>
+//!
+//! ## Compact identifiers
+//!
+//! Each node in a tree is assigned a unique identifier which uses `usize` by
+//! default, this can experimentally be changed by setting `--cfg
+//! syntree_compact` while building, causing it to use `u32` identifiers
+//! instead, which might improve performance under some circumstances.
 //!
 //! ```sh
 //! RUSTFLAGS="--cfg syntree_compact" cargo build
@@ -99,7 +160,7 @@
 //! [`close`], and [`token`] calls on [`Builder`] as specified.
 //!
 //! ```
-//! use syntree::{Span, Builder};
+//! use syntree::{Builder, Span};
 //!
 //! #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 //! enum Syntax {
@@ -268,7 +329,9 @@
 //! [`token`]: https://docs.rs/syntree/latest/syntree/struct.Builder.html#method.token
 //! [`Tree`]: https://docs.rs/syntree/latest/syntree/struct.Tree.html
 //! [`Builder`]: https://docs.rs/syntree/latest/syntree/struct.Builder.html
+//! [`Builder::new_with`]: https://docs.rs/syntree/latest/syntree/struct.Builder.html#method.new_with
 //! [`Error`]: https://docs.rs/syntree/latest/syntree/enum.Error.html
+//! [`span::Empty`]: https://docs.rs/syntree/latest/syntree/span/struct.Empty.html
 //! [abstract syntax trees]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 //! [any-syntax]: https://github.com/udoprog/syntree/blob/main/examples/iterator.rs
 //! [calculator]: https://github.com/udoprog/syntree/blob/main/examples/calculator

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,16 +1,17 @@
 //! Central struct to keep track of all internal linking of a tree.
 
 use crate::non_max::NonMax;
-use crate::Kind;
+use crate::span::Span;
+use crate::tree::Kind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Links<T, S> {
+pub struct Links<T, I> {
     /// The data in the node.
     pub(crate) data: T,
     /// The kind of the node.
     pub(crate) kind: Kind,
     /// Span of the node.
-    pub(crate) span: S,
+    pub(crate) span: Span<I>,
     /// Parent node. These exists because they are needed when performing range
     /// queries such as [Tree::node_with_range][crate::Tree::node_with_range].
     pub(crate) parent: Option<NonMax>,

--- a/src/print.rs
+++ b/src/print.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 use std::io::{Error, Write};
 
-use crate::span::{self, Span};
+use crate::span::{Index, Span};
 use crate::tree::{Kind, Tree};
 
 /// Pretty-print a tree without a source.
@@ -57,11 +57,11 @@ use crate::tree::{Kind, Tree};
 /// NUMBER@6..8
 ///   NUMBER@6..8 +
 /// ```
-pub fn print<O, T, S>(o: O, tree: &Tree<T, S>) -> Result<(), Error>
+pub fn print<O, T, I>(o: O, tree: &Tree<T, I>) -> Result<(), Error>
 where
     O: Write,
     T: fmt::Debug,
-    S: span::TreeSpan + fmt::Display,
+    I: Index + fmt::Display,
 {
     print_with_lookup(o, tree, |_| None)
 }
@@ -116,23 +116,24 @@ where
 /// NUMBER@6..8
 ///   NUMBER@6..8 "64"
 /// ```
-pub fn print_with_source<O, T>(o: O, tree: &Tree<T, Span>, source: &str) -> Result<(), Error>
+pub fn print_with_source<O, T, I>(o: O, tree: &Tree<T, I>, source: &str) -> Result<(), Error>
 where
     O: Write,
     T: fmt::Debug,
+    I: Index + fmt::Display,
 {
     print_with_lookup(o, tree, |span| source.get(span.range()))
 }
 
-fn print_with_lookup<'a, O, T, S>(
+fn print_with_lookup<'a, O, T, I>(
     mut o: O,
-    tree: &Tree<T, S>,
-    source: impl Fn(&S) -> Option<&'a str>,
+    tree: &Tree<T, I>,
+    source: impl Fn(&Span<I>) -> Option<&'a str>,
 ) -> Result<(), Error>
 where
     O: Write,
     T: fmt::Debug,
-    S: span::TreeSpan + fmt::Display,
+    I: Index + fmt::Display,
 {
     for (depth, node) in tree.walk().with_depths() {
         let n = depth * 2;


### PR DESCRIPTION
`Span` becomes `Span<I>` where `I` is implemented for `usize`, `u32`, and `Empty`. This makes it more akin to `Range<T>`, and should be replaceable with the latter at some point.