### PR TITLE
Rework and remove Kind enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syntree"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to be an efficient replacement for it (read more below).
 Add `syntree` to your crate:
 
 ```toml
-syntree = "0.14.0"
+syntree = "0.14.1"
 ```
 
 If you want a complete sample for how `syntree` can be used for parsing, see

--- a/README.md
+++ b/README.md
@@ -26,68 +26,6 @@ the [calculator example][calculator].
 
 <br>
 
-## Compact or empty spans
-
-Spans by default uses `u32`-based indexes and `usize`-based pointers, this
-can be changed from its default using the [`Builder::new_with`] constructor:
-
-```rust
-use syntree::{Builder, Span, Tree};
-
-let mut tree = Builder::<_, usize, u16>::new_with();
-
-tree.open("root")?;
-tree.open("child")?;
-tree.token("token", 100)?;
-tree.close()?;
-tree.open("child2")?;
-tree.close()?;
-tree.close()?;
-
-let tree = tree.build()?;
-
-let expected: Tree<_, usize, u32> = syntree::tree_with! {
-    "root" => {
-        "child" => { ("token", 100) },
-        "child2" => {}
-    }
-};
-
-assert_eq!(tree, expected);
-assert_eq!(tree.span(), Span::new(0, 100));
-```
-
-Combined with [`Empty`], this allows for building trees without the
-overhead of keeping track of spans:
-
-```rust
-use syntree::{Builder, Empty, Tree};
-
-let mut tree = Builder::<_, Empty, u32>::new_with();
-
-tree.open("root")?;
-tree.open("child")?;
-tree.token("token", Empty)?;
-tree.close()?;
-tree.open("child2")?;
-tree.close()?;
-tree.close()?;
-
-let tree = tree.build()?;
-
-let expected: Tree<_, Empty, usize> = syntree::tree_with! {
-    "root" => {
-        "child" => { "token" },
-        "child2" => {}
-    }
-};
-
-assert_eq!(tree, expected);
-assert!(tree.span().is_empty());
-```
-
-<br>
-
 ## Syntax trees
 
 This crate provides a way to efficiently model [abstract syntax trees]. The
@@ -194,6 +132,68 @@ its `Lit` children. Including the ones within `Nested`.
 Trees are usually constructed by parsing an input. This library encourages
 the use of a [handwritten pratt parser][pratt]. See the [calculator
 example][calculator] for a complete use case.
+
+<br>
+
+## Compact or empty spans
+
+Spans by default uses `u32`-based indexes and `usize`-based pointers, this
+can be changed from its default using the [`Builder::new_with`] constructor:
+
+```rust
+use syntree::{Builder, Span, Tree};
+
+let mut tree = Builder::<_, usize, u16>::new_with();
+
+tree.open("root")?;
+tree.open("child")?;
+tree.token("token", 100)?;
+tree.close()?;
+tree.open("child2")?;
+tree.close()?;
+tree.close()?;
+
+let tree = tree.build()?;
+
+let expected: Tree<_, usize, u32> = syntree::tree_with! {
+    "root" => {
+        "child" => { ("token", 100) },
+        "child2" => {}
+    }
+};
+
+assert_eq!(tree, expected);
+assert_eq!(tree.span(), Span::new(0, 100));
+```
+
+Combined with [`Empty`], this allows for building trees without the
+overhead of keeping track of spans:
+
+```rust
+use syntree::{Builder, Empty, Tree};
+
+let mut tree = Builder::<_, Empty, u32>::new_with();
+
+tree.open("root")?;
+tree.open("child")?;
+tree.token("token", Empty)?;
+tree.close()?;
+tree.open("child2")?;
+tree.close()?;
+tree.close()?;
+
+let tree = tree.build()?;
+
+let expected: Tree<_, Empty, usize> = syntree::tree_with! {
+    "root" => {
+        "child" => { "token" },
+        "child2" => {}
+    }
+};
+
+assert_eq!(tree, expected);
+assert!(tree.span().is_empty());
+```
 
 <br>
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,7 +7,7 @@ use crate::index::{Index, Indexes, Length};
 use crate::links::Links;
 use crate::pointer::{Pointer, Width};
 use crate::span::Span;
-use crate::tree::{Kind, Tree};
+use crate::tree::Tree;
 
 pub use self::checkpoint::Checkpoint;
 
@@ -192,7 +192,7 @@ where
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn open(&mut self, data: T) -> Result<W::Pointer, Error> {
-        let id = self.insert(data, Kind::Node, Span::point(self.cursor))?;
+        let id = self.insert(data, Span::point(self.cursor))?;
         self.parents.push(id);
         Ok(id)
     }
@@ -280,7 +280,7 @@ where
             self.tree.span_mut().end = self.cursor;
         }
 
-        let id = self.insert(value, Kind::Token, Span::new(start, self.cursor))?;
+        let id = self.insert(value, Span::new(start, self.cursor))?;
         self.sibling = Some(id);
 
         if !len.is_empty() {
@@ -484,7 +484,7 @@ where
         let next_id = W::Pointer::new(self.tree.len()).ok_or(Error::Overflow)?;
 
         let Some(links) = self.tree.get_mut(id) else {
-            let new_id = self.insert(data, Kind::Node, Span::point(self.cursor))?;
+            let new_id = self.insert(data, Span::point(self.cursor))?;
             self.sibling = Some(new_id);
             debug_assert_eq!(new_id, id, "new id should match the expected id");
             return Ok(new_id);
@@ -506,7 +506,6 @@ where
 
         let added = Links {
             data,
-            kind: Kind::Node,
             span,
             prev,
             parent,
@@ -601,7 +600,7 @@ where
     }
 
     /// Insert a new node.
-    fn insert(&mut self, data: T, kind: Kind, span: Span<I>) -> Result<W::Pointer, Error> {
+    fn insert(&mut self, data: T, span: Span<I>) -> Result<W::Pointer, Error> {
         let new = W::Pointer::new(self.tree.len()).ok_or(Error::Overflow)?;
 
         let prev = self.sibling.take();
@@ -609,7 +608,6 @@ where
 
         self.tree.push(Links {
             data,
-            kind,
             span,
             parent,
             prev,

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -1,8 +1,10 @@
 use crate::index::{Index, Indexes, Length};
 
-/// The empty span implementation.
+/// The empty [Index] implementation.
 ///
-/// This can be used in combination with [`Builder::new_with`].
+/// This can be used in combination with [`Builder::new_with`] to ensure that
+/// that tree does not store any information on spans, reducing overhead if this
+/// is not necessary.
 ///
 /// [`Builder::new_with`]: crate::Builder::new_with
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -44,11 +46,6 @@ impl Index for Empty {
 
     #[inline]
     fn len_to(self, _: Self) -> Self {
-        Empty
-    }
-
-    #[inline]
-    fn saturating_sub(self, _: Self) -> Self {
         Empty
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -15,26 +15,37 @@ mod sealed {
 /// Ensure u32 is smaller or equal to usize.
 const _: () = assert!(core::mem::size_of::<u32>() <= core::mem::size_of::<usize>());
 
-/// A type that can be used as an index in a tree.
+/// A type that can be used when referring to an index in a tree.
+///
+/// An index is a valid single component of a [Span][crate::Span], valid indexes
+/// are types such as `u32` and `usize`, but also [`Empty`][crate::Empty] in
+/// case indexing is not required.
+///
+/// See [Builder::new_with][crate::Builder::new_with].
 pub trait Index: Sized + Copy + cmp::Ord + cmp::Eq + self::sealed::Sealed {
     #[doc(hidden)]
     const EMPTY: Self;
+
     #[doc(hidden)]
     type Indexes<P>: Indexes<Self, P>
     where
         P: Copy;
+
     #[doc(hidden)]
     type Length: Length;
+
     #[doc(hidden)]
     fn is_empty(&self) -> bool;
+
     #[doc(hidden)]
     fn as_usize(self) -> usize;
+
     #[doc(hidden)]
     fn checked_add_len(self, other: Self::Length) -> Option<Self>;
+
     #[doc(hidden)]
     fn len_to(self, other: Self) -> Self::Length;
-    #[doc(hidden)]
-    fn saturating_sub(self, other: Self) -> Self;
+
     #[doc(hidden)]
     fn from_usize(value: usize) -> Option<Self>;
 }
@@ -96,11 +107,6 @@ impl Index for u32 {
     }
 
     #[inline]
-    fn saturating_sub(self, other: Self) -> Self {
-        u32::saturating_sub(self, other)
-    }
-
-    #[inline]
     fn from_usize(value: usize) -> Option<Self> {
         u32::try_from(value).ok()
     }
@@ -130,11 +136,6 @@ impl Index for usize {
     #[inline]
     fn len_to(self, other: Self) -> Self::Length {
         other.saturating_sub(self)
-    }
-
-    #[inline]
-    fn saturating_sub(self, other: Self) -> Self {
-        usize::saturating_sub(self, other)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,70 +24,6 @@
 //!
 //! <br>
 //!
-//! ## Compact or empty spans
-//!
-//! Spans by default uses `u32`-based indexes and `usize`-based pointers, this
-//! can be changed from its default using the [`Builder::new_with`] constructor:
-//!
-//! ```
-//! use syntree::{Builder, Span, Tree};
-//!
-//! let mut tree = Builder::<_, usize, u16>::new_with();
-//!
-//! tree.open("root")?;
-//! tree.open("child")?;
-//! tree.token("token", 100)?;
-//! tree.close()?;
-//! tree.open("child2")?;
-//! tree.close()?;
-//! tree.close()?;
-//!
-//! let tree = tree.build()?;
-//!
-//! let expected: Tree<_, usize, u32> = syntree::tree_with! {
-//!     "root" => {
-//!         "child" => { ("token", 100) },
-//!         "child2" => {}
-//!     }
-//! };
-//!
-//! assert_eq!(tree, expected);
-//! assert_eq!(tree.span(), Span::new(0, 100));
-//! # Ok::<_, Box<dyn std::error::Error>>(())
-//! ```
-//!
-//! Combined with [`Empty`], this allows for building trees without the
-//! overhead of keeping track of spans:
-//!
-//! ```
-//! use syntree::{Builder, Empty, Tree};
-//!
-//! let mut tree = Builder::<_, Empty, u32>::new_with();
-//!
-//! tree.open("root")?;
-//! tree.open("child")?;
-//! tree.token("token", Empty)?;
-//! tree.close()?;
-//! tree.open("child2")?;
-//! tree.close()?;
-//! tree.close()?;
-//!
-//! let tree = tree.build()?;
-//!
-//! let expected: Tree<_, Empty, usize> = syntree::tree_with! {
-//!     "root" => {
-//!         "child" => { "token" },
-//!         "child2" => {}
-//!     }
-//! };
-//!
-//! assert_eq!(tree, expected);
-//! assert!(tree.span().is_empty());
-//! # Ok::<_, Box<dyn std::error::Error>>(())
-//! ```
-//!
-//! <br>
-//!
 //! ## Syntax trees
 //!
 //! This crate provides a way to efficiently model [abstract syntax trees]. The
@@ -195,6 +131,70 @@
 //! Trees are usually constructed by parsing an input. This library encourages
 //! the use of a [handwritten pratt parser][pratt]. See the [calculator
 //! example][calculator] for a complete use case.
+//!
+//! <br>
+//!
+//! ## Compact or empty spans
+//!
+//! Spans by default uses `u32`-based indexes and `usize`-based pointers, this
+//! can be changed from its default using the [`Builder::new_with`] constructor:
+//!
+//! ```
+//! use syntree::{Builder, Span, Tree};
+//!
+//! let mut tree = Builder::<_, usize, u16>::new_with();
+//!
+//! tree.open("root")?;
+//! tree.open("child")?;
+//! tree.token("token", 100)?;
+//! tree.close()?;
+//! tree.open("child2")?;
+//! tree.close()?;
+//! tree.close()?;
+//!
+//! let tree = tree.build()?;
+//!
+//! let expected: Tree<_, usize, u32> = syntree::tree_with! {
+//!     "root" => {
+//!         "child" => { ("token", 100) },
+//!         "child2" => {}
+//!     }
+//! };
+//!
+//! assert_eq!(tree, expected);
+//! assert_eq!(tree.span(), Span::new(0, 100));
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! Combined with [`Empty`], this allows for building trees without the
+//! overhead of keeping track of spans:
+//!
+//! ```
+//! use syntree::{Builder, Empty, Tree};
+//!
+//! let mut tree = Builder::<_, Empty, u32>::new_with();
+//!
+//! tree.open("root")?;
+//! tree.open("child")?;
+//! tree.token("token", Empty)?;
+//! tree.close()?;
+//! tree.open("child2")?;
+//! tree.close()?;
+//! tree.close()?;
+//!
+//! let tree = tree.build()?;
+//!
+//! let expected: Tree<_, Empty, usize> = syntree::tree_with! {
+//!     "root" => {
+//!         "child" => { "token" },
+//!         "child2" => {}
+//!     }
+//! };
+//!
+//! assert_eq!(tree, expected);
+//! assert!(tree.span().is_empty());
+//! # Ok::<_, Box<dyn std::error::Error>>(())
+//! ```
 //!
 //! <br>
 //!
@@ -353,4 +353,4 @@ pub use self::empty::Empty;
 pub use self::error::Error;
 pub use self::node::node_impl::Node;
 pub use self::span::Span;
-pub use self::tree::{Kind, Tree};
+pub use self::tree::Tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! Add `syntree` to your crate:
 //!
 //! ```toml
-//! syntree = "0.14.0"
+//! syntree = "0.14.1"
 //! ```
 //!
 //! If you want a complete sample for how `syntree` can be used for parsing, see

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,14 +1,11 @@
 //! Central struct to keep track of all internal linking of a tree.
 
 use crate::span::Span;
-use crate::tree::Kind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Links<T, I, P> {
     /// The data in the node.
     pub(crate) data: T,
-    /// The kind of the node.
-    pub(crate) kind: Kind,
     /// Span of the node.
     pub(crate) span: Span<I>,
     /// Parent node. These exists because they are needed when performing range

--- a/src/node/ancestors.rs
+++ b/src/node/ancestors.rs
@@ -2,7 +2,6 @@ use core::iter::FusedIterator;
 
 use crate::node::{Node, SkipTokens};
 use crate::pointer::Width;
-use crate::tree::Kind;
 
 /// An iterator that iterates over the [`Node::parent`] elements of a node. This
 /// is used for iterating over the ancestors of a node.
@@ -64,8 +63,8 @@ where
         Self { node }
     }
 
-    /// Construct a [`SkipTokens`] iterator from the remainder of this
-    /// iterator. This filters out [`Kind::Token`] elements.
+    /// Construct a [`SkipTokens`] iterator from the remainder of this iterator.
+    /// This filters out childless nodes, also known as tokens.
     ///
     /// See [`SkipTokens`] for documentation.
     #[inline]
@@ -103,13 +102,7 @@ where
     /// ```
     #[inline]
     pub fn next_node(&mut self) -> Option<Node<'_, T, I, W>> {
-        loop {
-            let node = self.next()?;
-
-            if matches!(node.kind(), Kind::Node) {
-                return Some(node);
-            }
-        }
+        self.find(|n| n.has_children())
     }
 }
 

--- a/src/node/children.rs
+++ b/src/node/children.rs
@@ -3,7 +3,6 @@ use core::iter::FusedIterator;
 use crate::links::Links;
 use crate::node::{Node, SkipTokens};
 use crate::pointer::{Pointer, Width};
-use crate::tree::Kind;
 
 /// An iterator that iterates over the [`Node::next`] elements of a node. This is
 /// typically used for iterating over the children of a tree.
@@ -16,7 +15,9 @@ use crate::tree::Kind;
 /// let mut tree = syntree::tree! {
 ///     "root" => {
 ///         "child1" => {
-///             "child2" => {}
+///             "child2" => {
+///                 "token1"
+///             }
 ///         },
 ///         "child3" => {}
 ///     }
@@ -90,8 +91,8 @@ where
         Self { tree, first, last }
     }
 
-    /// Construct a [`SkipTokens`] iterator from the remainder of this
-    /// iterator. This filters out [`Kind::Token`] elements.
+    /// Construct a [`SkipTokens`] iterator from the remainder of this iterator.
+    /// This filters out childless nodes, also known as tokens.
     ///
     /// See [`SkipTokens`] for documentation.
     #[must_use]
@@ -106,13 +107,19 @@ where
     ///
     /// ```
     /// let tree = syntree::tree! {
-    ///     ("t1", 1),
-    ///     "child1" => {},
-    ///     ("t2", 1),
-    ///     "child2" => {},
-    ///     ("t3", 1),
-    ///     "child3" => {},
-    ///     ("t4", 1)
+    ///     ("token1", 1),
+    ///     "child1" => {
+    ///         "token2"
+    ///     },
+    ///     ("token3", 1),
+    ///     "child2" => {
+    ///         "token4"
+    ///     },
+    ///     ("token5", 1),
+    ///     "child3" => {
+    ///         "token6"
+    ///     },
+    ///     ("token7", 1)
     /// };
     ///
     /// let mut it = tree.children();
@@ -127,13 +134,7 @@ where
     /// ```
     #[inline]
     pub fn next_node(&mut self) -> Option<Node<'_, T, I, W>> {
-        loop {
-            let node = self.next()?;
-
-            if matches!(node.kind(), Kind::Node) {
-                return Some(node);
-            }
-        }
+        self.find(|n| n.has_children())
     }
 }
 

--- a/src/node/siblings.rs
+++ b/src/node/siblings.rs
@@ -3,7 +3,6 @@ use core::iter::FusedIterator;
 use crate::links::Links;
 use crate::node::{Node, SkipTokens};
 use crate::pointer::{Pointer, Width};
-use crate::tree::Kind;
 
 /// An iterator that iterates over the [`Node::next`] elements of a node. This is
 /// typically used for iterating over the children of a tree.
@@ -16,9 +15,13 @@ use crate::tree::Kind;
 /// let mut tree = syntree::tree! {
 ///     "root" => {
 ///         "child1" => {
-///             "child2" => {}
+///             "child2" => {
+///                 "token1"
+///             }
 ///         },
-///         "child3" => {}
+///         "child3" => {
+///             "token2"
+///         }
 ///     }
 /// };
 ///
@@ -35,12 +38,18 @@ use crate::tree::Kind;
 /// let mut tree = syntree::tree! {
 ///     "root" => {
 ///         "child1" => {
-///             "child2" => {}
+///             "child2" => {
+///                 "token1"
+///             }
 ///         },
-///         "child3" => {}
+///         "child3" => {
+///             "token2"
+///         }
 ///     },
 ///     "root2" => {
-///         "child4" => {}
+///         "child4" => {
+///             "token3"
+///         }
 ///     }
 /// };
 ///
@@ -76,8 +85,8 @@ where
         }
     }
 
-    /// Construct a [`SkipTokens`] iterator from the remainder of this
-    /// iterator. This filters out [`Kind::Token`] elements.
+    /// Construct a [`SkipTokens`] iterator from the remainder of this iterator.
+    /// This filters out childless nodes, also known as tokens.
     ///
     /// See [`SkipTokens`] for documentation.
     #[must_use]
@@ -92,13 +101,19 @@ where
     ///
     /// ```
     /// let tree = syntree::tree! {
-    ///     ("t1", 1),
-    ///     "child1" => {},
-    ///     ("t2", 1),
-    ///     "child2" => {},
-    ///     ("t3", 1),
-    ///     "child3" => {},
-    ///     ("t4", 1)
+    ///     ("token1", 1),
+    ///     "child1" => {
+    ///         "token2"
+    ///     },
+    ///     ("token3", 1),
+    ///     "child2" => {
+    ///         "token4"
+    ///     },
+    ///     ("token5", 1),
+    ///     "child3" => {
+    ///         "token6"
+    ///     },
+    ///     ("token7", 1)
     /// };
     ///
     /// let first = tree.first().ok_or("missing first")?;
@@ -115,13 +130,7 @@ where
     /// ```
     #[inline]
     pub fn next_node(&mut self) -> Option<Node<'_, T, I, W>> {
-        loop {
-            let node = self.next()?;
-
-            if matches!(node.kind(), Kind::Node) {
-                return Some(node);
-            }
-        }
+        self.find(|n| n.has_children())
     }
 }
 

--- a/src/node/walk.rs
+++ b/src/node/walk.rs
@@ -85,8 +85,8 @@ where
         WithDepths { iter: self }
     }
 
-    /// Construct a [`SkipTokens`] iterator from the remainder of this
-    /// iterator. This filters out [`Kind::Token`][crate::Kind::Token] elements.
+    /// Construct a [`SkipTokens`] iterator from the remainder of this iterator.
+    /// This filters out childless nodes, also known as tokens.
     ///
     /// See [`SkipTokens`] for documentation.
     #[inline]
@@ -95,7 +95,7 @@ where
         SkipTokens::new(self)
     }
 
-    /// Get the next element with a corresponding depth.
+    /// Get the next node with a corresponding depth.
     ///
     /// Alternatively you can use [`WithDepths`] through [`Walk::with_depths`].
     ///
@@ -167,13 +167,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let (e, node) = self.iter.next()?;
-
-            if !matches!(e, Event::Up) {
-                return Some(node);
-            }
-        }
+        Some(self.iter.find(|(e, _)| !matches!(e, Event::Up))?.1)
     }
 }
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -23,12 +23,15 @@ pub trait Pointer: Sized + Copy + hash::Hash + Eq + fmt::Debug + self::sealed::S
 /// This is determined by a primitive unsigned types such as `u32` or `usize`.
 pub trait Width: self::sealed::Sealed {
     #[doc(hidden)]
+    const EMPTY: Self;
+    #[doc(hidden)]
     type Pointer: Pointer;
 }
 
 macro_rules! implement {
     ($ty:ident, $non_zero:ident) => {
         impl Width for $ty {
+            const EMPTY: Self = 0;
             type Pointer = self::$ty::NonMax;
         }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -6,7 +6,7 @@ use std::io::{Error, Write};
 use crate::index::Index;
 use crate::pointer::Width;
 use crate::span::Span;
-use crate::tree::{Kind, Tree};
+use crate::tree::Tree;
 
 /// Pretty-print a tree without a source.
 ///
@@ -145,17 +145,12 @@ where
         let data = node.value();
         let span = node.span();
 
-        match node.kind() {
-            Kind::Token => {
-                if let Some(source) = source(span) {
-                    writeln!(o, "{:n$}{:?}@{} {:?}", "", data, span, source, n = n)?;
-                } else {
-                    writeln!(o, "{:n$}{:?}@{} +", "", data, span, n = n)?;
-                }
-            }
-            Kind::Node => {
-                writeln!(o, "{:n$}{:?}@{}", "", data, span, n = n)?;
-            }
+        if node.has_children() {
+            writeln!(o, "{:n$}{:?}@{}", "", data, span, n = n)?;
+        } else if let Some(source) = source(span) {
+            writeln!(o, "{:n$}{:?}@{} {:?}", "", data, span, source, n = n)?;
+        } else {
+            writeln!(o, "{:n$}{:?}@{} +", "", data, span, n = n)?;
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,16 +8,6 @@ use crate::node::{Children, Walk, WalkEvents};
 use crate::pointer::{Pointer, Width};
 use crate::span::Span;
 
-/// The kind of a node in the [Tree].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Kind {
-    /// A node.
-    Node,
-    /// The token and a corresponding span.
-    Token,
-}
-
 /// A syntax tree.
 ///
 /// A tree is constructed through a [Builder][crate::Builder] or by modifying an
@@ -48,9 +38,9 @@ where
     /// cursor each time it is modified and allow for binary searching for
     /// sequences of nodes which corresponds to the given index.
     indexes: I::Indexes<W::Pointer>,
-    /// The first element in the tree.
+    /// The first node in the tree.
     first: Option<W::Pointer>,
-    /// The last element in the tree.
+    /// The last node in the tree.
     last: Option<W::Pointer>,
 }
 
@@ -257,7 +247,7 @@ where
         self.tree.get_mut(id.get())
     }
 
-    /// Push a new element onto the tree.
+    /// Push a new node into the tree with the specified links.
     pub(crate) fn push(&mut self, links: Links<T, I, W::Pointer>) {
         self.tree.push(links);
     }


### PR DESCRIPTION
The `Kind` enum is being removed in favor of simply having children or not (which can be checked through `Node::has_children`). That means that opening and immediately closing a node counts as a "token".