### PR TITLE
Fix checkpoint bug

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -618,7 +618,7 @@ where
         let node = F::Pointer::new(self.tree.len()).ok_or(Error::Overflow)?;
 
         if let Some(c) = &self.checkpoint {
-            if c.node() == node {
+            if c.node() == node && c.parent() == self.parent {
                 return Ok(c.clone());
             }
         }

--- a/src/builder/checkpoint.rs
+++ b/src/builder/checkpoint.rs
@@ -32,6 +32,10 @@ where
         self.0.get().node
     }
 
+    pub(crate) fn parent(&self) -> Option<P> {
+        self.0.get().parent
+    }
+
     pub(crate) fn get(&self) -> (P, Option<P>) {
         let Inner { node, parent } = self.0.get();
         (node, parent)

--- a/tests/checkpoints.rs
+++ b/tests/checkpoints.rs
@@ -123,3 +123,30 @@ fn test_nested_checkpoints2() -> Result<()> {
     assert_eq!(tree, expected);
     Ok(())
 }
+
+#[test]
+fn test_checkpoints_around_close() -> Result<()> {
+    let mut tree = syntree::Builder::new();
+
+    tree.open("operation")?;
+    tree.token("b", 3)?;
+    let _ = tree.checkpoint()?; // this line *shouldn't* affect anything but it triggers the bug
+    tree.close()?;
+    let b = tree.checkpoint()?;
+    tree.token("a", 3)?;
+    tree.close_at(&b, "operation")?;
+
+    let tree = tree.build()?;
+
+    let expected = syntree::tree! {
+        "operation" => {
+            ("b", 3)
+        },
+        "operation" => {
+            ("a", 3)
+        }
+    };
+
+    assert_eq!(tree, expected);
+    Ok(())
+}


### PR DESCRIPTION
I found a bug while trying to use syntree for a project. The bug happens when you take a checkpoint, close a node, then take a checkpoint again, the second checkpoint is still a clone of the first one with the wrong parent. Added a test to verify that it fails, and then fixed the test.